### PR TITLE
add jwt token auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
 			<artifactId>vertx-web-templ-freemarker</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>3.4.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/szmirren/vxApi/spi/auth/VxApiAuthFactory.java
+++ b/src/main/java/com/szmirren/vxApi/spi/auth/VxApiAuthFactory.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.szmirren.vxApi.core.common.StrUtil;
 import com.szmirren.vxApi.core.entity.VxApis;
+import com.szmirren.vxApi.spi.auth.impl.VxApiAuthJwtTokenImpl;
 import com.szmirren.vxApi.spi.auth.impl.VxApiAuthSessionTokenImpl;
 
 import io.vertx.core.http.HttpClient;
@@ -21,6 +22,8 @@ public class VxApiAuthFactory {
 	 * sessionToken的实现类名称
 	 */
 	public final static String SESSION_TOKEN_AUTH = "sessionTokenAuth";
+	
+	public final static String JWT_TOKEN_AUTH = "jwtTokenAuth";
 
 	/**
 	 * 获得所有实现类的名字
@@ -50,6 +53,9 @@ public class VxApiAuthFactory {
 		}
 		if (SESSION_TOKEN_AUTH.equalsIgnoreCase(name)) {
 			return new VxApiAuthSessionTokenImpl(options);
+		}
+		if (JWT_TOKEN_AUTH.equalsIgnoreCase(name)) {
+			return new VxApiAuthJwtTokenImpl(options);
 		}
 		throw new ClassNotFoundException("没有找到名字为 : " + name + " 的API权限验证实现类");
 	}

--- a/src/main/java/com/szmirren/vxApi/spi/auth/impl/VxApiAuthJwtTokenImpl.java
+++ b/src/main/java/com/szmirren/vxApi/spi/auth/impl/VxApiAuthJwtTokenImpl.java
@@ -1,0 +1,160 @@
+package com.szmirren.vxApi.spi.auth.impl;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.szmirren.vxApi.core.common.ResultFormat;
+import com.szmirren.vxApi.core.common.VxApiGatewayAttribute;
+import com.szmirren.vxApi.core.enums.ContentTypeEnum;
+import com.szmirren.vxApi.core.enums.HTTPStatusCodeMsgEnum;
+import com.szmirren.vxApi.core.enums.ParamPositionEnum;
+import com.szmirren.vxApi.spi.auth.VxApiAuth;
+import com.szmirren.vxApi.spi.common.HttpHeaderConstant;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * JWTToken权限认证实现类
+ * 
+ * @author onemy
+ *
+ */
+public class VxApiAuthJwtTokenImpl implements VxApiAuth {
+	private static final Logger LOG = LogManager.getLogger(VxApiAuthJwtTokenImpl.class);
+	/**
+	 * 存放Session中token值key的名字
+	 */
+	private final static String VX_API_JWT_TOKEN_NAME = "apiToken";
+	/**
+	 * 存放请求参数中token值key的名字
+	 */
+	private final static String VX_API_USER_TOKEN_NAME = "apiName";
+
+	private String apiTokenName;// 存在API网关token值的key名字
+	private String userTokenName;// 用户请求token值的key名字
+	private ParamPositionEnum userTokenScope = ParamPositionEnum.HEADER;// 用户请求token存放的位置,默认为header
+	private ContentTypeEnum authFailContentType = ContentTypeEnum.JSON_UTF8;// 认证失败返回结果的contentType,默认json-utf8
+	private String authFailResult;// 认证失败返回结果
+	
+	private JsonArray userKeys;
+
+	@Override
+	public void handle(RoutingContext event) {
+		String token=event.request().getHeader(apiTokenName);
+		String username=event.request().getHeader(userTokenName);
+		String userKey=null;
+		
+		if(username==null||username.equals("")){
+			event.response().putHeader(HttpHeaderConstant.SERVER, VxApiGatewayAttribute.FULL_NAME)
+			.putHeader(HttpHeaderConstant.CONTENT_TYPE, authFailContentType.val()).end(authFailResult);
+		}
+		
+		for(Object object: userKeys){
+			if(object instanceof JsonObject){
+				if(((JsonObject) object).getString(username) instanceof String){
+					userKey=((JsonObject) object).getString(username);
+				}
+			}
+		}
+		
+		LOG.info("userKey:"+userKey);
+		
+		if(userKey==null||userKey.equals("")){
+			event.response().putHeader(HttpHeaderConstant.SERVER, VxApiGatewayAttribute.FULL_NAME)
+			.putHeader(HttpHeaderConstant.CONTENT_TYPE, authFailContentType.val()).end(authFailResult);
+		}
+		
+		JWTVerifier verifier=JWT.require(Algorithm.HMAC256(userKey)).build();
+		DecodedJWT jwt=null;
+
+		try{
+			jwt=verifier.verify(token);
+			event.next();
+		}catch(Exception e){
+			event.response().putHeader(HttpHeaderConstant.SERVER, VxApiGatewayAttribute.FULL_NAME)
+			.putHeader(HttpHeaderConstant.CONTENT_TYPE, authFailContentType.val()).end(authFailResult);
+			
+			//throw new RuntimeException("凭证无效或己过期！");
+		}
+		
+		/*
+		Session session = event.session();
+		if (session == null) {
+			event.response().putHeader(HttpHeaderConstant.SERVER, VxApiGatewayAttribute.FULL_NAME)
+					.putHeader(HttpHeaderConstant.CONTENT_TYPE, authFailContentType.val()).end(authFailResult);
+		} else {
+			// session中的token
+			String apiToken = session.get(apiTokenName) == null ? null : session.get(apiTokenName).toString();
+			// 用户request中的token
+			String userTokoen = null;
+			if (userTokenScope == ParamPositionEnum.HEADER) {
+				userTokoen = event.request().getHeader(userTokenName);
+			} else {
+				userTokoen = event.request().getParam(userTokenName);
+			}
+			// 检验请求是否正确如果正确放行反则不通过
+			if (!StrUtil.isNullOrEmpty(apiToken) && apiToken.equals(userTokoen)) {
+				event.next();
+			} else {
+				event.response().putHeader(HttpHeaderConstant.SERVER, VxApiGatewayAttribute.FULL_NAME)
+						.putHeader(HttpHeaderConstant.CONTENT_TYPE, authFailContentType.val()).end(authFailResult);
+			}
+		}
+		*/
+	}
+
+	/**
+	 * @param obj
+	 *          通过一个JsonObject实例化一个对象 <br>
+	 *          obj.apiTokenName = API中token的名字<br>
+	 *          obj.userTokenName = 用户token在请求中的名字<br>
+	 *          obj.userTokenScope =
+	 *          用户token在请求中的名字所在的位置枚举类型{@link ParamPositionEnum} 默认在HEADER中<br>
+	 *          obj.authFailContentType =
+	 *          验证不通过时返回的Content-Type枚举类型{@link ContentTypeEnum} 默认为JSON_UTF8<br>
+	 *          obj.authFailResult = 验证不通过时的返回结果 默认为
+	 *          {@link ResultFormat}.formatAsNull({@link HTTPStatusCodeMsgEnum}.C401)<br>
+	 */
+	public VxApiAuthJwtTokenImpl(JsonObject obj) {
+		if (obj == null) {
+			throw new NullPointerException("JwtToken认证方式的配置文件不能为空!");
+		}
+		if (obj.getValue("apiTokenName") instanceof String) {
+			this.apiTokenName = obj.getString("apiTokenName");
+		} else {
+			this.apiTokenName = VX_API_JWT_TOKEN_NAME;
+		}
+		if (obj.getValue("userTokenName") instanceof String) {
+			this.userTokenName = obj.getString("userTokenName");
+		} else {
+			this.userTokenName = VX_API_USER_TOKEN_NAME;
+		}
+
+		if(obj.getJsonArray("secretKeys") instanceof JsonArray){
+			this.userKeys=obj.getJsonArray("secretKeys");
+
+		}
+
+		if (obj.getValue("userTokenScope") instanceof String) {
+			this.userTokenScope = ParamPositionEnum.valueOf(obj.getString("userTokenScope"));
+		} else {
+			this.userTokenScope = ParamPositionEnum.HEADER;
+		}
+		if (obj.getValue("authFailContentType") instanceof String) {
+			this.authFailContentType = ContentTypeEnum.valueOf(obj.getString("authFailContentType"));
+		} else {
+			this.authFailContentType = ContentTypeEnum.JSON_UTF8;
+		}
+		if (obj.getValue("authFailResult") instanceof String) {
+			this.authFailResult = obj.getString("authFailResult");
+		} else {
+			this.authFailResult = ResultFormat.formatAsNull(HTTPStatusCodeMsgEnum.C401);
+		}
+	}
+}

--- a/src/main/resources/static/CreateAPI.html
+++ b/src/main/resources/static/CreateAPI.html
@@ -160,6 +160,7 @@
                                                 class="console-selectbox console-width-4 ng-pristine ng-valid">
                                             <option value="none" class="ng-binding">不认证</option>
                                             <option value="sessionTokenAuth" class="ng-binding">session-token</option>
+                                            <option value="jwtTokenAuth" class="ng-binding">JWT-token</option>
                                         </select>
                                     </div>
                                 </div>

--- a/src/main/resources/static/js/APISelectChange.js
+++ b/src/main/resources/static/js/APISelectChange.js
@@ -9,6 +9,8 @@ $("#auth-options-name").change(function () {
         $("#auth-options-config").val('{\n"apiTokenName":"vxApiSessionToken",\n"userTokenName":"vxApiUserToken",\n"userTokenScope":"HEADER",\n"authFailContentType":"HTML_UTF8",\n"authFailResult":"Unauthorized"\n}');
         $(".auth-hide-show").show();
     } else {
+    	$("#auth-options-config").val('');
+    	$("#auth-options-config").val('{\n"apiTokenName":"apiToken",\n"userTokenName":"apiName",\n"secretKeys":[{"admin":"secret"},{"test":"123456"}]}');
         $(".auth-hide-show").show();
     }
 });

--- a/src/main/resources/templates/updateAPI.ftl
+++ b/src/main/resources/templates/updateAPI.ftl
@@ -163,6 +163,7 @@
                                                 </#if>
                                             <option value="none" class="ng-binding">不认证</option>
                                             <option value="sessionTokenAuth" class="ng-binding">session-token</option>
+                                            <option value="jwtTokenAuth" class="ng-binding">JWT-token</option>
                                         </select>
                                     </div>
                                 </div>


### PR DESCRIPTION
1、安全认证，增加jwtTokenAuth授权认证
2、认证配置文件说明
{
"apiTokenName":"apiToken",			//非必须，请求头使用的KEY，值为加密token串，默认apiToken
"userTokenName":"apiName",			//非必须，请求头使用的KEY，值为用户名，默认apiName
"secretKeys":[{"admin":"secret"},{"test":"123456"}]	,	//必须，用户名及密钥数组
"userTokenScope":"HEADER",			// 非必须，用户请求token存放的位置,默认为header
"authFailContentType":"HTML_UTF8",		// 非必须，认证失败返回结果的contentType,默认json-utf8
"authFailResult":"Unauthorized"			// 非必须，认证失败返回结果
}
3、请求示例
header 参数
apiToken jwt-xxxxxxxxxxxxxxx（详情参考jwt生成方式）
apiName username（使用上面配置数组中的用户名）
